### PR TITLE
Support subdomains on .onion

### DIFF
--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -65,7 +65,7 @@ SOCKS_errors = {
     0x00: "error_sock_generic.tpl",
     0x23: "error_sock_hs_not_found.tpl",
     0x24: "error_sock_hs_not_reachable.tpl"
-}
+}r
 
 
 class T2WRPCServer(pb.Root):
@@ -1364,10 +1364,10 @@ ipv6 = config.listen_ipv6
 
 rexp = {
     'body': re.compile(r'(<body.*?\s*>)', re.I),
-    'w2t': re.compile(r'(http:|https:)?//([a-z0-9]{16})\.' + config.basehost, re.I),
-    't2w': re.compile(r'(http:|https:)?//([a-z0-9]{16})\.onion', re.I),
-    'set-cookie_t2w': re.compile(r'domain=(\.*)([a-z0-9]{16})\.onion(\b)?', re.I),
-    'html_t2w': re.compile( r'(href|src|url|action)([\ ]*=[\ ]*[\'\"]?)(?:http:|https:)?//([a-z0-9]{16})\.onion([\ \'\"/])', re.I)
+    'w2t': re.compile(r'(http:|https:)?//([a-z0-9\.]*[a-z0-9]{16})\.' + config.basehost, re.I),
+    't2w': re.compile(r'(http:|https:)?//([a-z0-9\.]*[a-z0-9]{16})\.onion', re.I),
+    'set-cookie_t2w': re.compile(r'domain=(\.*)([a-z0-9\.]*[a-z0-9]{16})\.onion(\b)?', re.I),
+    'html_t2w': re.compile( r'(href|src|url|action)([\s]*=[\s]*[\'\"]?)(?:http:|https:)?//([a-z0-9\.]*[a-z0-9]{16})\.onion([\ \'\"/])', re.I)
 }
 
 # ##############################################################################


### PR DESCRIPTION
They are officially allowed, and in fact sometimes used, see: http://muflax65ngodyewp.onion as an example.

Also changed spaces [\ ] to [\s] because on that same site, muflax65ngodyewp.onion, they use a newline instead of spaces.  With this patch everything on the page is recognized correctly.