### PR TITLE
allow for subdomains on .onion

### DIFF
--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -1364,10 +1364,10 @@ ipv6 = config.listen_ipv6
 
 rexp = {
     'body': re.compile(r'(<body.*?\s*>)', re.I),
-    'w2t': re.compile(r'(http:|https:)?//([a-z0-9]{16})\.' + config.basehost, re.I),
-    't2w': re.compile(r'(http:|https:)?//([a-z0-9]{16})\.onion', re.I),
-    'set-cookie_t2w': re.compile(r'domain=(\.*)([a-z0-9]{16})\.onion(\b)?', re.I),
-    'html_t2w': re.compile( r'(href|src|url|action)([\ ]*=[\ ]*[\'\"]?)(?:http:|https:)?//([a-z0-9]{16})\.onion([\ \'\"/])', re.I)
+    'w2t': re.compile(r'(http:|https:)?//([a-z0-9\.]*[a-z0-9]{16})\.' + config.basehost, re.I),
+    't2w': re.compile(r'(http:|https:)?//([a-z0-9\.]*[a-z0-9]{16})\.onion', re.I),
+    'set-cookie_t2w': re.compile(r'domain=(\.*)([a-z0-9\.]*[a-z0-9]{16})\.onion(\b)?', re.I),
+    'html_t2w': re.compile( r'(href|src|url|action)([\s]*=[\s]*[\'\"]?)(?:http:|https:)?//([a-z0-9\.]*[a-z0-9]{16})\.onion([\ \'\"/])', re.I)
 }
 
 # ##############################################################################


### PR DESCRIPTION
For example, the links on page: http://muflax65ngodyewp.onion/

The replace of [\ ] for [\s] is to allow for newlines as well as spaces as done on http://muflax65ngodyewp.onion/ .