### PR TITLE
black_list blocking now handles subdomains

### DIFF
--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -990,7 +990,10 @@ class T2WRequest(http.Request):
                         defer.returnValue(NOT_DONE_YET)
 
                 elif config.mode == "BLACKLIST":
-                    if hashlib.md5(self.obj.onion).hexdigest() in black_list:
+                   # the self.obj.onion[-22:] is to block subdomains as well.
+                    if hashlib.md5(self.obj.onion).hexdigest() in black_list or 
+                       hashlib.md5(self.obj.onion[-22:]).hexdigest() in black_list:
+
                         self.sendError(403, 'error_hs_completely_blocked.tpl')
                         defer.returnValue(NOT_DONE_YET)
 

--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -991,8 +991,8 @@ class T2WRequest(http.Request):
 
                 elif config.mode == "BLACKLIST":
                    # the self.obj.onion[-22:] is to block subdomains as well.
-                    if hashlib.md5(self.obj.onion).hexdigest() in black_list or 
-                       hashlib.md5(self.obj.onion[-22:]).hexdigest() in black_list:
+                    if( hashlib.md5(self.obj.onion).hexdigest() in black_list or 
+                        hashlib.md5(self.obj.onion[-22:]).hexdigest() in black_list ):
 
                         self.sendError(403, 'error_hs_completely_blocked.tpl')
                         defer.returnValue(NOT_DONE_YET)


### PR DESCRIPTION
When you block 0123456789abcdefg.onion, the subdomains *.0123456789abcdefg.onion will also be blocked.