### PR TITLE
removed RedirectAgent overwrite

### DIFF
--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -364,19 +364,6 @@ class Agent(client.Agent):
                                               parsedURI.originForm)
         defer.returnValue(ret)
 
-class RedirectAgent(client.RedirectAgent):
-    """
-    Overridden client.RedirectAgent version where we evaluate and handle automatically only HTTPS redirects
-    """
-    def _handleResponse(self, response, method, uri, headers, redirectCount):
-        locationHeaders = response.headers.getRawHeaders('location', [])
-        if locationHeaders:
-            location = self._resolveLocation(uri, locationHeaders[0])
-            parsed = client._URI.fromBytes(location)
-            if parsed.scheme == 'https':
-                return client.RedirectAgent._handleResponse(self, response, method, uri, headers, redirectCount)
-
-        return response
 
 class T2WRequest(http.Request):
     """
@@ -995,16 +982,13 @@ class T2WRequest(http.Request):
                         defer.returnValue(NOT_DONE_YET)
 
             agent = Agent(reactor, sockhost=config.sockshost, sockport=config.socksport, pool=self.pool)
-            ragent = RedirectAgent(agent, 1)
 
             if config.dummyproxy is None:
                 proxy_url = self.obj.address
             else:
                 proxy_url = 'normal-' + config.dummyproxy + parsed[2] + '?' + parsed[3]
 
-            self.proxy_d = ragent.request(self.method,
-                                          proxy_url,
-                                          self.obj.headers, bodyProducer=producer)
+            self.proxy_d = agent.request(self.method, proxy_url, self.obj.headers, bodyProducer=producer)
 
             self.proxy_d.addCallback(self.cbResponse)
             self.proxy_d.addErrback(self.handleError)


### PR DESCRIPTION
As far as I can tell we don't need this overwrite.  The TBB allows funny redirects, and TBB has higher security expectations than tor2web. Ergo I argue in favor of removing this code.