### PR TITLE
URL and query string normalization for blocklist

### DIFF
--- a/tor2web/utils/urls.py
+++ b/tor2web/utils/urls.py
@@ -1,0 +1,41 @@
+"""
+
+:mod:`Tor2Web`
+=====================================================
+
+.. automodule:: Tor2Web
+   :synopsis: URL Routines
+
+.. moduleauthor:: Anuj Gupta <dev@anuj.me>
+
+"""
+
+# -*- coding: utf-8 -*-
+
+import urlparse
+import urllib
+
+
+def sort_querystring(query_string):
+    """Sort a query string using field names and urlencode it"""
+    # Split the query string into parts
+    qs_parts = urlparse.parse_qsl(query_string)
+    # Sort the parts (by field) and remove duplicates
+    qs_parts = sorted(set(qs_parts))
+    # Return sorted query string
+    return urllib.urlencode(qs_parts)
+
+
+def normalize_url(url):
+    """Produce a normalized, blockable url"""
+    # Split the URL into parts
+    url_parts = urlparse.urlsplit(url)
+    # We don't need 'scheme' or 'fragment'
+    base,path,qs = url_parts[1:4]
+    # Sort the query string
+    qs_norm = sort_querystring(qs)
+    if qs_norm:
+        qs_norm = '?' + qs_norm
+    # Generate the normalized url
+    url_norm = ''.join([base,path,qs_norm])
+    return url_norm


### PR DESCRIPTION
1. urlsplit works better than urlparse since it ignores the rarely-used query string 'params'. This also fixes a bug introduced in the last commit (parsed[3] reference at https://github.com/globaleaks/Tor2web/blob/master/tor2web/t2w.py#L987)
2. New functions for normalizing URLs and query strings added to utils/urls.py.
3. Normalization is performed at both sides of the block list - while adding new urls to the cleartext blocklist as well as while searching inside `block_list`.

Normalization helps block query string URLs more effectively. Previously, simply changing the order of querystring fields would cause a blocked URL to be exposed. In addition, query string fields are now properly encoded.

For example, if the cleartext blocklist contains `blahblahblahblah.onion/a/b/c?d=e&f=g` the following URLs are normalized and thus, also blocked:

 - blahblahblahblah.onion/a/b/c?d=e&f=g&d=e (duplicate query items)
 - blahblahblahblah.onion/a/b/c?f=g&d=e (different ordering)
 - blahblahblahblah.onion/a/b/c?f=g&d=e&xyz= (unused query items)

In addition, blocklist entries prefixed with the protocol (or 'scheme') are now possible:

 - http://blahblahblahblah.onion
 - https://blahblahblahblah.onion/a/b/c?f=g&d=e&xyz=
