### PR TITLE
Support for blocking child URLs

### DIFF
--- a/tor2web/utils/urls.py
+++ b/tor2web/utils/urls.py
@@ -39,3 +39,12 @@ def normalize_url(url):
     # Generate the normalized url
     url_norm = ''.join([base,path,qs_norm])
     return url_norm
+
+
+def parent_urls(url, limit=0):
+    """Generate parent urls above 'limit' level (0 = base)"""
+    # Clean up the url
+    url = normalize_url(url.rstrip('/'))
+    # Yield parent urls from second-last level down to 'limit'
+    for i in range(1, url.count('/')+1-limit):
+        yield url.rsplit('/', i)[0] + '/'


### PR DESCRIPTION
As described in https://github.com/globaleaks/Tor2web/issues/280 -

If a blocklist (hashed or cleartext) contains `blahblahblahblah.onion/some/path`, all of the following will now be blocked:

 - blahblahblahblah.onion/some/path/file1.php
 - blahblahblahblah.onion/some/path/file2.php
 - blahblahblahblah.onion/some/path/path2
 - blahblahblahblah.onion/some/path/some/other/path

Example use case: A legitimate image hosting website blahblahblahblah.onion has a new user posting illegal images at `blahblahblahblah.onion/baduser/1.jpg`, `blahblahblahblah.onion/baduser/2.jpg` etc. We can now just block `blahblahblahblah.onion/baduser/` without affecting the rest of the website.

We've encountered this multiple times at OnionLink and it seems like a good balance between matching only exact URLs and hashing every character. I've included the use of sets in order to minimize the amount of hashing performed.