### PR TITLE
Fixed mixed-content warnings on HTTPS

### DIFF
--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -605,6 +605,7 @@ class T2WRequest(http.Request):
 
         if self.isSecure():
             self.setHeader(b'strict-transport-security', b'max-age=31536000')
+            self.setHeader(b'Content-Security-Policy', b'upgrade-insecure-requests')
 
         if config.mode == 'TRANSLATION':
             # no additional headers are injected when in translation mode

--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -604,7 +604,7 @@ class T2WRequest(http.Request):
         self.setHeader(b'content-length', intToBytes(len(data)))
 
         if self.isSecure():
-            self.setHeader(b'strict-transport-security', b'max-age=31536000')
+            self.setHeader(b'strict-transport-security', b'max-age=31536000; includeSubDomains')
             self.setHeader(b'Content-Security-Policy', b'upgrade-insecure-requests')
 
         if config.mode == 'TRANSLATION':


### PR DESCRIPTION
Example page: https://w363zoq3ylux5rf5.onion.link/

Example fix: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/fixing-mixed-content?hl=en

Now if the website owner links to http:// for included elements, we request over HTTPS anyway.