### PR TITLE
updated checktor test url

### DIFF
--- a/misc/checktor.js
+++ b/misc/checktor.js
@@ -10,7 +10,7 @@ function checkTor(yes_cb, no_cb, test_url) {
   // redirects the user to provided url
   try {
     if (typeof(test_url) === 'undefined') {
-      var test_url = 'https://antani.tor2web.org/checktor';
+      var test_url = 'https://antani.onion.to/checktor';
     }
     if (window.XMLHttpRequest) {
       var xmlhttp = new XMLHttpRequest();


### PR DESCRIPTION
old value's HTTPS certificate was invalid for antani.tor2web.org since it is only valid for onion.to and *.onion.to