### PR TITLE
fix some stuff ...

### DIFF
--- a/bin/tor2web.sh
+++ b/bin/tor2web.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+tor2web=./bin/tor2web
+#tor2web=tor2web
+
+datadir=/run/user/$UID/tor2web-data
+
+if ! [ -e tor2web.conf ]; then
+  cp -v tor2web.conf.example tor2web.conf
+fi
+
+mkdir -p $datadir
+mkdir -p $datadir/certs
+mkdir -p $datadir/logs
+mkdir -p $datadir/run
+
+touch $datadir/certs/tor2web-key.pem
+touch $datadir/certs/tor2web-cert.pem
+
+if ! [ -e $datadir/templates/ ]; then
+  cp -r data/templates/ $datadir/
+fi
+
+if [ -e $datadir/run/rpc.socket ]; then
+  rm $datadir/run/rpc.socket
+fi
+
+exec $tor2web -c tor2web.conf --rundir $datadir/run --pidfile $datadir/tor2web.pid --nodaemon

--- a/tor2web.conf.example
+++ b/tor2web.conf.example
@@ -1,0 +1,121 @@
+# Tor2web configuration file
+[main]
+
+listen_port_http = 1582
+listen_port_https = 15443
+
+# Unique nodename identifier
+# nodename = [UNIQUE_IDENTIFIER]
+# nodename = localhost
+
+# Path to Tor2web data directory
+# datadir = /home/tor2web
+datadir = /run/user/1000/tor2web-data
+
+# Debug and logging
+# logreqs = False
+# debugmode = False
+# debugtostdout = False
+logreqs = True
+debugmode = True
+debugtostdout = True
+
+# Processes (suggested number of cores + 1)
+# processes = 5
+# requests_per_process = 100000
+# processes = 1
+
+# Ip addresses and ports
+# transport = BOTH
+# listen_ipv4 = [LISTENING_IPV4_ADDRESS]
+# listen_ipv6 = [LISTENING_IPV6_ADDRESS]
+# listen_port_http = 80
+# listen_port_https = 443
+
+# This is the base hostname for the current tor2web node
+# basehost = AUTO
+# basehost = localhost
+
+# This is the SOCKS host and port on which Tor is listening
+# sockshost = 127.0.0.1
+# socksport = 9050
+# socksoptimisticdata = True
+# sockmaxpersistentperhost = 5
+# sockcachedconnectiontimeout = 240
+# sockretryautomatically = True
+
+# SSL configuration
+
+# TODO
+disable_ssl = True
+
+# TODO
+inject_header = False
+
+# ssl_key = /home/tor2web/certs/tor2web-key.pem
+# ssl_cert = /home/tor2web/certs/tor2web-cert.pem
+
+# BE SURE TO CONFIGURE THE INTERMEDIATE CA OR YOUR WEB BROWSER WILL RESPOND
+# WITH VERY LOUD WARNINGS AND ERRORS
+# ssl_intermediate = /home/tor2web/certs/tor2web-intermediate.pem
+# TO GENERATE DH Parameters:
+#    $ cd /home/tor2web/certs/
+#    $ openssl dhparam -out tor2web-dh.pem 2048
+
+# ssl_dh = /home/tor2web/certs/tor2web-dh.pem
+# cipher_list = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA
+# ssl_tofu_cache_size = 100
+
+# Access Blocking
+# mode = BLOCKLIST
+# onion = None
+# blockhotlinking = True
+# blockhotlinking_exts = [jpg, png, gif]
+
+
+# Add special HTTP headers
+# This option makes it possible to add headers to responses sent to clients.
+# Do NOT use this unless you are positive you need it.
+# extra_HTTP_headers_to_response = [ 'Cache-Control: max-age=600', 'Surrogate-Control: max-age=86400' ]
+
+# Disable the automagical redirect of Tor user on Tor HSs
+# disable_tor_redirection = False
+
+# If set to True will disable the tor2web disclaimer
+# disable_disclaimer = False
+disable_disclaimer = True
+
+# If set to True will disable the tor2web banner
+# disable_banner = False
+
+# If set to True will avoid rewriting visible data (experimental; will result
+# in less functional proxy) Could be useful in relation to DMCA for US law only
+# avoid_rewriting_visible_content = True
+avoid_rewriting_visible_content = False
+
+# Mail configuration for automatic exception and user abuse notifications
+# smtpuser = [USERNAME]
+# smtppass = [PASSWORD]
+# smtpmail = [EMAIL]
+# smtpmailto_exceptions = [EMAIL_FOR_ABUSES_EXCEPTIONS]
+# smtpmailto_notifications = [EMAIL_FOR_ABUSES_NOTIFICATION]
+# smtpdomain = [DOMAIN]
+# smtpport = [PORT]
+
+# Exit nodes list refresh period (in seconds)
+# exit_node_list_refresh = 600
+
+# Enables the automatic fetching of the hashed blocklist
+# automatic_blocklist_updates_source = https://ahmia.fi/bannedMD5.txt
+# automatic_blocklist_updates_refresh = 600
+# automatic_blocklist_updates_mode = MERGE
+
+# This publishes blocklist which will be available at::/antanistaticmap/lists/blocklist
+# publish_blocklist = False
+
+# List of mirrors shown in Tor2web disclaimer and banner
+# An updated list of know mirrors can be found at: https://github.com/globaleaks/tor2web/wiki
+# mirror = [tor2web.org, mirror2.tld, mirror3.tld, ...]
+
+# This allows Tor2web to make use of a simple TCP proxies
+# dummyproxy = https://127.0.0.1:8080


### PR DESCRIPTION
- fix regex bytestrings: `b"...\1..."` to `rb"...\1..."`
- fix rewriting of html content: remove condition `if len(data) >= config.bufsize * 2`
- remove deprecated `intToBytes`
- add debug prints
- add bin/tor2web.sh - all of this init stuff should be done by tor2web/t2w.py on the first run. this should also work when tor2web is installed as a python package
- add tor2web.conf.example

tor2web is still not working properly
for me, it runs, but fails to handle any requests... it just hangs

dont know whats wrong, maybe related to content rewriting

```
$ ./bin/tor2web.sh
/nix/store/a3m02l8fwa776p3i28qh1nl3lmv8amxx-tor2web-3.2.0-unstable-2022-07-15/lib/python3.11/site-packages/tor2web/t2w.py:24: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  from cgi import parse_header
2024-05-24 13:48:43+0200 [-] Log opened.
2024-05-24 13:48:43+0200 [-] PBServerFactory starting on '/run/user/1000/tor2web-data/run/rpc.socket'
2024-05-24 13:48:43+0200 [-] Starting factory <twisted.spread.pb.PBServerFactory object at 0x7f57adcad210>
/nix/store/a3m02l8fwa776p3i28qh1nl3lmv8amxx-tor2web-3.2.0-unstable-2022-07-15/lib/python3.11/site-packages/tor2web/t2w.py:24: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  from cgi import parse_header
/nix/store/a3m02l8fwa776p3i28qh1nl3lmv8amxx-tor2web-3.2.0-unstable-2022-07-15/lib/python3.11/site-packages/tor2web/t2w.py:780: DeprecationWarning: twisted.web.http.Request.getClientIP was deprecated in Twisted 18.4.0; please use getClientAddress instead
  self.obj.client_ip = self.getClientIP()
Fri, 24 May 2024 11:48:47 GMT detected <onion_url>.tor2web Hostname: piratebayo3klnzokct3wt5yyxb2vpebbuyjl7m623iaxmqhsd52coid.onion
2024-05-24 13:48:48+0200 [-] Starting factory _HTTP11ClientFactory(<function HTTPConnectionPool._newConnection.<locals>.quiescentCallback at 0x7f57adc6f380>, <twisted.internet.endpoints._WrapperEndpoint object at 0x7f57ae5e5cd0>)
2024-05-24 13:48:48+0200 [-] Stopping factory _HTTP11ClientFactory(<function HTTPConnectionPool._newConnection.<locals>.quiescentCallback at 0x7f57adc6f380>, <twisted.internet.endpoints._WrapperEndpoint object at 0x7f57ae5e5cd0>)
```
